### PR TITLE
Fix missing path_to_su heading and incorrect LSAM_0_255 description

### DIFF
--- a/docs/configuration/parameters/lsam-configuration-parameters.md
+++ b/docs/configuration/parameters/lsam-configuration-parameters.md
@@ -104,13 +104,23 @@ If setting the MAX_NUMBER_OF_JOBS_TO_RUN parameter to a high value (i.e., greate
 
 ### LSAM_0_255
 
+**Default Value**: 0
+
+**Description**:
+
+Controls how the agent reports job exit codes in the range 128–255 to OpCon.
+
+* If set to zero (default), exit codes in the range 128–255 are reported as negative values (for example, exit code 255 is reported as -1, and exit code 128 is reported as -128).
+* If set to one, exit codes are reported in the 0–255 range without conversion.
+
+### path_to_su
+
 **Default Value**: yes
 
 **Description**:
 
 This is the global configuration setting for how the agent will impersonate users when running jobs. For a full discussion of the options, please refer to "Considerations for path_to_su" below this table.
 
- 
 The options for this setting include:
 
 * no: Setting the value to no causes the agent to use the legacy method of user impersonation for all jobs.


### PR DESCRIPTION
## Summary

- The `LSAM_0_255` parameter section was missing its description entirely, and the `path_to_su` section heading was missing — causing path_to_su's description and default value (`yes`) to appear under the `LSAM_0_255` heading.
- Added the correct `LSAM_0_255` description and default (`0`): controls whether exit codes 128–255 are reported as negative values or kept in the 0–255 range, verified against `monitor_job.c`, `monitor_pre.c`, and `lsam_config.h`.
- Restored the `### path_to_su` heading above the description that belongs to it.

## Test plan

- [ ] Verify `LSAM_0_255` section shows default `0` and correct exit code conversion description
- [ ] Verify `path_to_su` section appears as a separate heading with default `yes`
- [ ] Confirm "Considerations for path_to_su" section below remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)